### PR TITLE
fix some translation errors

### DIFF
--- a/index-mx.html
+++ b/index-mx.html
@@ -89,11 +89,11 @@
           <p>Veo mucho potencial en Cardano debido a su fuerte visión y proceso metódico, por lo que estoy muy feliz de brindar el servicio de administrar un stake pool confiable para la comunidad que fomenta el crecimiento y la fortaleza de la red.</p>
 
           <h4 class="mt-4">Cuál es la configuración de este stake pool?</h4>
-          <p>El grupo funciona con tres servidores privados virtuales redundantes y confiables, un productor de bloques y dos relés distribuidos en diferentes centros de datos en Europa / Alemania y Asia / Singapur. Con esta configuración redundante, el grupo STR8 nunca pierde un bloque, incluso durante las ventanas de mantenimiento.</p>
+          <p>El grupo funciona con tres servidores privados virtuales redundantes y confiables, un productor de bloques y dos relés distribuidos en diferentes centros de datos en Europa / Alemania y Asia / Singapur. Con esta configuración redundante, el stake pool STR8 nunca pierde un bloque, incluso durante las ventanas de mantenimiento.</p>
           <p>Todos los nodos se ejecutan en un sistema operativo de servidor seguro y moderno con amplios recursos de hardware y un fuerte emparejamiento con opciones de escalado fáciles para satisfacer las crecientes demandas.</p>
           <p>No quiero aburrirlo con datos elaborados de monitoreo en tiempo real de este stake pool, puedes esperar que el stake pool funcione para usted las 24 horas del día, los 7 días de la semana.</p> 
     
-          <h4 class="mt-4">Cuáles son sus planes para el futuro de su piscina?</h4>
+          <h4 class="mt-4">Cuáles son sus planes para el futuro de su stake pool?</h4>
           <p>Dirijo este grupo porque creo en el futuro de Cardano y quiero ser parte de la comunidad. Por esta razón, planeo mantener este grupo de forma indefinida. Haré todo lo posible para que el stake pool funcione de la mejor manera posible.</p>
 
           <p>Participo activamente en el grupo de Telegram del grupo de trabajo de mejores prácticas de <a href="https://t.me/CardanoStakePoolWorkgroup">Cardano Shelley Testnet y StakePool</a> para ayudar a hacer crecer la comunidad e implementar todas las mejores prácticas para este grupo y desarrollar nuevas mejores prácticas a lo largo del camino.</p>
@@ -105,9 +105,9 @@
           <p>No subiré repentinamente mis tarifas variables por encima del 4% como lo harán eventualmente otros grupos que comienzan con estructuras de tarifas insostenibles. Como delegador quiero darte tranquilidad al delegar en mi grupo.</p>
 
           <h4 class="mt-4">Qué quiere decir con una tarifa "efectiva" del 4%?</h4>
-          <p>No estoy de acuerdo con tomar una tarifa fija de 340 ADA independientemente de la cantidad de bloques que STR8 pool produzca. Mi razón es la solidaridad contigo, mi muy apreciado delegador. Al confiar solo en el margen de beneficio, compartimos el riesgo. Creo en Cardano y estamos juntos en esto. El grupo STR8 comparte los días buenos y malos con sus delegadores confiando únicamente en la tarifa variable. Para ejecutar un grupo único y sostenible, STR8 requiere solo ~ 4.0% de la tarifa efectiva.</p>
+          <p>No estoy de acuerdo con tomar una tarifa fija de 340 ADA independientemente de la cantidad de bloques que STR8 pool produzca. Mi razón es la solidaridad contigo, mi muy apreciado delegador. Al confiar solo en el margen de beneficio, compartimos el riesgo. Creo en Cardano y estamos juntos en esto. el stake pool STR8 comparte los días buenos y malos con sus delegadores confiando únicamente en la tarifa variable. Para ejecutar un grupo único y sostenible, STR8 requiere solo ~ 4.0% de la tarifa efectiva.</p>
           <p>
-            Siempre que haya una tarifa fija obligatoria de 340 ADA, el grupo STR8 utiliza una tarifa variable del 3.00%. En caso de que la participación total caiga por debajo de los 5 millones de ADA, el grupo STR8 volverá a entrar en modo bootstrap, reduciendo la tarifa variable al 0,00%. En caso de que se elimine la bandera obligatoria de tarifa fija en el futuro, el grupo STR8
+            Siempre que haya una tarifa fija obligatoria de 340 ADA, el stake pool STR8 utiliza una tarifa variable del 3.00%. En caso de que la participación total caiga por debajo de los 5 millones de ADA, el stake pool STR8 volverá a entrar en modo bootstrap, reduciendo la tarifa variable al 0,00%. En caso de que se elimine la bandera obligatoria de tarifa fija en el futuro, el stake pool STR8
             reduzca la tarifa fija a 0 ADA y aumente la tarifa variable al 4,00%.
           </p>
           <p>
@@ -217,7 +217,7 @@
           <p>Las actualizaciones se publican en <a href="https://twitter.com/Straightpool4">Twitter</a> y en <a href="https://t.me/str8pool">el grupo Telegram Straightpool</a>.</p>
           <p>Actualmente, no hay planes para configurar una lista de correo para delegadores, ya que es posible que la red principal de Shelley tenga algún tipo de mensajería de billetera en las billeteras oficiales, que le permite a el operador de el stake pool comunicar con los delegadores. Ya tenemos suficiente correo no deseado, me gustaría minimizar cualquier correo no deseado adicional al no contribuir a recopilar otra lista de correo propensa al abuso.</p>
 
-          <h4 class="mt-4">Cuál es el origen del nombre de esta piscina?</h4>
+          <h4 class="mt-4">Cuál es el origen del nombre de este stake pool?</h4>
           <p>Directo en el sentido de, directo y directo de alta calidad, audio de alta calidad, sin trucos, simplemente funciona.</p>
 
           <h4 class="mt-4">Dónde puedo aprender más sobre todo esto?</h4>


### PR DESCRIPTION
1) There should be no instances of the word "piscina", which is the literal translation of the word "pool". Looks like i missed a few

2) Similarly, there are a few instances of "el grupo STR8" which should be replaced with "el stake pool STR8"
